### PR TITLE
Remove Google+ link

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,11 +192,10 @@
                             <li><a class="footerlink" href="https://forum.kontalk.org/">Forum</a></li>
                             </ul>
                         </div>
-			<div class="social four columns"><!-- Social Buttons -->
+			<div class="social three columns"><!-- Social Buttons -->
 				<ul>
 					<li class="border-5"><a href="https://www.facebook.com/kontalknet"><i class="fa fa-facebook"></i></a></li>
 					<li class="border-5"><a href="https://twitter.com/kontalknet"><i class="fa fa-twitter"></i></a></li>
-					<li class="border-5"><a href="https://plus.google.com/u/0/102201749813756709299"><i class="fa fa-google-plus"></i></a></li>
 					<li class="border-5"><a href="https://github.com/kontalk"><i class="fa fa-github"></i></a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
Google+ is dead. Let's remove the link to it.

Closes https://github.com/kontalk/website.org/issues/1